### PR TITLE
ansible 2.16 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: REDIS_EXPORTER | Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - install
 
 - name: REDIS_EXPORTER | Configure
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - configure
 
 - name: REDIS_EXPORTER | Service
-  include: service.yml
+  include_tasks: service.yml
   tags:
     - service


### PR DESCRIPTION
replace include by include_tasks so it will be ansible 2.16 compatible as option has been deprecated
